### PR TITLE
Add cbor2

### DIFF
--- a/robostack.yaml
+++ b/robostack.yaml
@@ -786,6 +786,8 @@ python3-catkin-tools:
   robostack: [catkin_tools]
 python3-cantools-pip:
   robostack: [cantools]
+python3-cbor2:
+  robostack: [cbor2]
 python3-cherrypy3:
   robostack: [cherrypy]
 python3-click:


### PR DESCRIPTION
Under the assumption that this solves:

```
pixi init --channel conda-forge --channel robostack-kilted
pixi add ros-kilted-ros2launch ros-kilted-rosbridge-server
pixi run ros2 launch rosbridge_server rosbridge_websocket_launch.xml
✔ Created /home/tim/pixi/cbor2/pixi.toml
✔ Added ros-kilted-ros2launch >=0.28.5,<0.29
✔ Added ros-kilted-rosbridge-server >=3.1.0,<4
[INFO] [launch]: All log files can be found below /home/tim/.ros/log/2026-04-16-12-48-35-650368-clephas-2123796
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [rosbridge_websocket-1]: process started with pid [2123869]
[INFO] [rosapi_node-2]: process started with pid [2123871]
[rosbridge_websocket-1] Traceback (most recent call last):
...
[rosbridge_websocket-1]   File "/home/tim/pixi/cbor2/.pixi/envs/default/lib/python3.12/site-packages/rosbridge_library/internal/outgoing_message.py", line 5, in <module>
[rosbridge_websocket-1]     from cbor2 import dumps as encode_cbor
[rosbridge_websocket-1] ModuleNotFoundError: No module named 'cbor2'
```