### PR TITLE
Bump dependee as well

### DIFF
--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -168,3 +168,5 @@ rosx_introspection:
 # Remove all lines after this one on new full rebuild
 rosbridge_library:
   build_number: 18
+rosbridge_server:
+  build_number: 18


### PR DESCRIPTION
Because:

```
$ rm pixi.toml; pixi init --channel conda-forge --channel robostack-kilted; pixi add ros-kilted-ros2launch ros-kilted-rosbridge-server; pixi run ros2 launch rosbridge_server rosbridge_websocket_launch.xml
✔ Created /home/tim/pixi/cbor2/pixi.toml
✔ Added ros-kilted-ros2launch >=0.28.5,<0.29
✔ Added ros-kilted-rosbridge-server >=3.1.0,<4
[INFO] [launch]: All log files can be found below /home/tim/.ros/log/2026-04-17-09-20-32-484094-clephas-3075926
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [rosbridge_websocket-1]: process started with pid [3075953]
[INFO] [rosapi_node-2]: process started with pid [3075955]
[rosbridge_websocket-1] Traceback (most recent call last):
...
[rosbridge_websocket-1]   File "/home/tim/pixi/cbor2/.pixi/envs/default/lib/python3.12/site-packages/rosbridge_library/internal/outgoing_message.py", line 5, in <module>
[rosbridge_websocket-1]     from cbor2 import dumps as encode_cbor
[rosbridge_websocket-1] ModuleNotFoundError: No module named 'cbor2'
[ERROR] [rosbridge_websocket-1]: process has died [pid 3075953, exit code 1, cmd '/home/tim/pixi/cbor2/.pixi/envs/default/lib/rosbridge_server/rosbridge_websocket --ros-args -r __node:=rosbridge_websocket -r __ns:=/ --params-file /tmp/launch_params_d_e2l8la --params-file /tmp/launch_params_smic4z3e --params-file /tmp/launch_params_otsn9nw7 --params-file /tmp/launch_params_kagngknb --params-file /tmp/launch_params_s0z4i3zy --params-file /tmp/launch_params_nr3cc6g7 --params-file /tmp/launch_params_fsgoxgl8 --params-file /tmp/launch_params_6mj7djy2 --params-file /tmp/launch_params_swg0to83 --params-file /tmp/launch_params_n0s_40ch --params-file /tmp/launch_params_qaryz6z0 --params-file /tmp/launch_params_iruxs99z --params-file /tmp/launch_params_sj0kukwz --params-file /tmp/launch_params__fnd99o8 --params-file /tmp/launch_params_ibsx6i67 --params-file /tmp/launch_params_mbq8dg3l --params-file /tmp/launch_params_qvnuk5z1'].

$ pixi list
Name                                               Version       Build                        Size  Kind   Source
...                       0.38.3        np2py312h2ed9cc7_17     77.81 KiB  conda  https://conda.anaconda.org/robostack-kilted
ros-kilted-rosapi                                  3.1.0         np2py312h2ed9cc7_17     59.13 KiB  conda  https://conda.anaconda.org/robostack-kilted
ros-kilted-rosapi-msgs                             3.1.0         np2py312h2ed9cc7_17   1000.11 KiB  conda  https://conda.anaconda.org/robostack-kilted
ros-kilted-rosbridge-library                       3.1.0         np2py312h2ed9cc7_17    129.90 KiB  conda  https://conda.anaconda.org/robostack-kilted
ros-kilted-rosbridge-msgs                          3.1.0         np2py312h2ed9cc7_17     89.95 KiB  conda  https://conda.anaconda.org/robostack-kilted
ros-kilted-rosbridge-server                        3.1.0         np2py312h2ed9cc7_17     58.96 KiB  conda  https://conda.anaconda.org/robostack-kilted
ros-kilted-rosgraph-msgs                           2.3.1         np2py312h2ed9cc7_17     70.44 KiB  conda  https://conda.anaconda.org/robostack-kilted
...
```

Or should I be doing something else @traversaro 