### PR TITLE
add point-cloud-transport-plugins

### DIFF
--- a/rosdistro_snapshot.yaml
+++ b/rosdistro_snapshot.yaml
@@ -1032,29 +1032,29 @@ desktop_full:
   url: https://github.com/ros2-gbp/variants-release.git
   version: 0.12.0
 diagnostic_aggregator:
-  tag: release/kilted/diagnostic_aggregator/4.3.6-1
+  tag: release/kilted/diagnostic_aggregator/4.3.7-1
   url: https://github.com/ros2-gbp/diagnostics-release.git
-  version: 4.3.6
+  version: 4.3.7
 diagnostic_common_diagnostics:
-  tag: release/kilted/diagnostic_common_diagnostics/4.3.6-1
+  tag: release/kilted/diagnostic_common_diagnostics/4.3.7-1
   url: https://github.com/ros2-gbp/diagnostics-release.git
-  version: 4.3.6
+  version: 4.3.7
 diagnostic_msgs:
   tag: release/kilted/diagnostic_msgs/5.5.2-1
   url: https://github.com/ros2-gbp/common_interfaces-release.git
   version: 5.5.2
 diagnostic_remote_logging:
-  tag: release/kilted/diagnostic_remote_logging/4.3.6-1
+  tag: release/kilted/diagnostic_remote_logging/4.3.7-1
   url: https://github.com/ros2-gbp/diagnostics-release.git
-  version: 4.3.6
+  version: 4.3.7
 diagnostic_updater:
-  tag: release/kilted/diagnostic_updater/4.3.6-1
+  tag: release/kilted/diagnostic_updater/4.3.7-1
   url: https://github.com/ros2-gbp/diagnostics-release.git
-  version: 4.3.6
+  version: 4.3.7
 diagnostics:
-  tag: release/kilted/diagnostics/4.3.6-1
+  tag: release/kilted/diagnostics/4.3.7-1
   url: https://github.com/ros2-gbp/diagnostics-release.git
-  version: 4.3.6
+  version: 4.3.7
 diff_drive_controller:
   tag: release/kilted/diff_drive_controller/5.13.1-1
   url: https://github.com/ros2-gbp/ros2_controllers-release.git

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -210,7 +210,6 @@ packages_select_by_deps:
       - apriltag_detector_mit
       - dual-laser-merger
       - pointcloud-to-laserscan
-      - diagnostic-remote-logging
       - point-cloud-transport-plugins
       - laser-segmentation
       - rqt_tf_tree

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -210,6 +210,7 @@ packages_select_by_deps:
       - apriltag_detector_mit
       - dual-laser-merger
       - pointcloud-to-laserscan
+      - point-cloud-transport-plugins
       - laser-segmentation
       - rqt_tf_tree
       - rviz_satellite

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -210,6 +210,7 @@ packages_select_by_deps:
       - apriltag_detector_mit
       - dual-laser-merger
       - pointcloud-to-laserscan
+      - diagnostic-remote-logging
       - point-cloud-transport-plugins
       - laser-segmentation
       - rqt_tf_tree


### PR DESCRIPTION
It doesn't work on windows in the other distros. 

This also adds the `diagnostic_remote_logging` package to kilted.