### PR TITLE
Add ament_cmake_clang_tidy to build selection

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -44,6 +44,7 @@ packages_select_by_deps:
   - ament_cmake_core
   - ament_cmake_catch2
   - ament_cmake_mypy
+  - ament_cmake_clang_tidy
 
   - ros_base
   - ros_environment


### PR DESCRIPTION
## Summary

`ament_cmake_clang_tidy` is present in `rosdistro_snapshot.yaml` but was not being built or published to the `robostack-kilted` channel.

The reason: this repo only generates recipes for packages listed in `packages_select_by_deps` (plus their transitive dependencies). `ament_cmake_clang_tidy` is a linter package that is only a *test* dependency of other packages, so it never gets pulled in transitively — it has to be selected explicitly, just like the sibling linters `ament_cmake_mypy` and `ament_cmake_black` already are.

This PR adds it to `packages_select_by_deps` so a recipe is generated and the `ros-kilted-ament-cmake-clang-tidy` conda package gets built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)