### PR TITLE
Reintroduce library_path.sh patches from humble to fix LD_LIBRARY_PATH pollution

### DIFF
--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -7,7 +7,7 @@ env:
   # Change to 'true' to enable the cache upload as artifacts
   SAVE_CACHE_AS_ARTIFACT: 'true'
   # Change to 'true' to ignore cache and force a full rebuild, but please restore to 'false' before merging
-  IGNORE_CACHE_AND_DO_FULL_REBUILD: 'true'
+  IGNORE_CACHE_AND_DO_FULL_REBUILD: 'false'
 
 jobs:
   build:

--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -7,7 +7,7 @@ env:
   # Change to 'true' to enable the cache upload as artifacts
   SAVE_CACHE_AS_ARTIFACT: 'true'
   # Change to 'true' to ignore cache and force a full rebuild, but please restore to 'false' before merging
-  IGNORE_CACHE_AND_DO_FULL_REBUILD: 'false'
+  IGNORE_CACHE_AND_DO_FULL_REBUILD: 'true'
 
 jobs:
   build:

--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -288,3 +288,6 @@ pinocchio:
   add_host: ["eigen-abi-devel"]
 eigenpy:
   add_host: ["eigen-abi-devel"]
+warehouse_ros_sqlite:
+  add_host: ["ros-kilted-sqlite3-vendor"]
+  add_run: ["ros-kilted-sqlite3-vendor"]

--- a/patch/ros-kilted-ament-cmake-core.patch
+++ b/patch/ros-kilted-ament-cmake-core.patch
@@ -1,0 +1,18 @@
+diff --git a/cmake/package_templates/templates_2_cmake.py b/cmake/package_templates/templates_2_cmake.py
+index b7c0faf..328cc38 100644
+--- a/cmake/package_templates/templates_2_cmake.py
++++ b/cmake/package_templates/templates_2_cmake.py
+@@ -68,12 +68,7 @@ def generate_cmake_code():
+     """
+     variables = []
+ 
+-    if not IS_WINDOWS:
+-        variables.append((
+-            'ENVIRONMENT_HOOK_LIBRARY_PATH',
+-            '"%s"' % get_environment_hook_template_path('library_path.sh')))
+-    else:
+-        variables.append(('ENVIRONMENT_HOOK_LIBRARY_PATH', ''))
++    variables.append(('ENVIRONMENT_HOOK_LIBRARY_PATH', ''))
+ 
+     ext = '.bat.in' if IS_WINDOWS else '.sh.in'
+     variables.append((

--- a/patch/ros-kilted-ament-package.patch
+++ b/patch/ros-kilted-ament-package.patch
@@ -1,0 +1,22 @@
+diff --git a/ament_package/template/environment_hook/library_path.sh b/ament_package/template/environment_hook/library_path.sh
+deleted file mode 100644
+index 292e518..0000000
+--- a/ament_package/template/environment_hook/library_path.sh
++++ /dev/null
+@@ -1,16 +0,0 @@
+-# copied from ament_package/template/environment_hook/library_path.sh
+-
+-# detect if running on Darwin platform
+-_UNAME=`uname -s`
+-_IS_DARWIN=0
+-if [ "$_UNAME" = "Darwin" ]; then
+-  _IS_DARWIN=1
+-fi
+-unset _UNAME
+-
+-if [ $_IS_DARWIN -eq 0 ]; then
+-  ament_prepend_unique_value LD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX/lib"
+-else
+-  ament_prepend_unique_value DYLD_LIBRARY_PATH "$AMENT_CURRENT_PREFIX/lib"
+-fi
+-unset _IS_DARWIN

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -5,12 +5,12 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-# Reminder for next full rebuild, the next build number should be 21
-build_number: 20
+# Reminder for next full rebuild, the next build number should be 22
+build_number: 21
 
 mutex_package:
   name: "ros2-distro-mutex"
-  version: "0.16.0"
+  version: "0.17.0"
   upper_bound: "x.x"
   run_constraints:
     - libboost 1.90.*


### PR DESCRIPTION
Same patch ported from [ros-jazzy](https://github.com/RoboStack/ros-jazzy/pull/233)