### PR TITLE
Bump ament_index_cpp

### DIFF
--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -168,6 +168,8 @@ ublox_gps:
 rosx_introspection:
   additional_cmake_args: "-DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON"
 
-# Remove on next rebuild
+# Remove everything after this line on a full rebuild
+ament_index_cpp:
+  build_number: 22
 camera_calibration:
   build_number: 22

--- a/rosdistro_snapshot.yaml
+++ b/rosdistro_snapshot.yaml
@@ -248,9 +248,9 @@ ament_flake8:
   url: https://github.com/ros2-gbp/ament_lint-release.git
   version: 0.19.2
 ament_index_cpp:
-  tag: release/kilted/ament_index_cpp/1.11.3-1
+  tag: release/kilted/ament_index_cpp/1.11.4-1
   url: https://github.com/ros2-gbp/ament_index-release.git
-  version: 1.11.3
+  version: 1.11.4
 ament_index_python:
   tag: release/kilted/ament_index_python/1.11.3-1
   url: https://github.com/ros2-gbp/ament_index-release.git


### PR DESCRIPTION
Same logic as https://github.com/RoboStack/ros-jazzy/pull/245:

https://github.com/ament/ament_index/compare/1.11.3...1.11.4

Reason for specifically pushing this one is that `get_package_share_directory.hpp` is no longer present on lyrical. And switching everywhere to `get_package_share_path.hpp` is easier than working with conditionals around it.