### PR TITLE
Although released to the buildfarm, magic_enum is not really a ROS package

### DIFF
--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -7,10 +7,6 @@ octomap:
   generate_dummy_package_with_run_deps:
     dep_name: octomap
     max_pin: 'x.x'
-magic_enum:
-  generate_dummy_package_with_run_deps:
-    dep_name: magic_enum
-    max_pin: 'x.x'
 ompl:
   generate_dummy_package_with_run_deps:
     dep_name: ompl

--- a/robostack.yaml
+++ b/robostack.yaml
@@ -610,6 +610,8 @@ lua5.2-dev:
   robostack: [lua]
 lz4:
   robostack: [lz4]
+magic_enum:
+  robostack: [magic_enum]
 maven:
   robostack: [maven]
 mongodb:

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -152,8 +152,6 @@ packages_select_by_deps:
   - polygon_msgs
   - ros2_fmt_logger
 
-  - magic_enum
-
   - better_launch
   - cm_executors
   - py-trees


### PR DESCRIPTION
I released it, but now we compile every sync while it's already available on conda.