### PR TITLE
fix: ros2 cli autocompletions

### DIFF
--- a/patch/ros-kilted-ros2cli.patch
+++ b/patch/ros-kilted-ros2cli.patch
@@ -1,0 +1,31 @@
+diff --git a/ros2cli/completion/ros2-argcomplete.zsh b/ros2cli/completion/ros2-argcomplete.zsh
+index b9fc309..14279de 100644
+--- a/ros2cli/completion/ros2-argcomplete.zsh
++++ b/ros2cli/completion/ros2-argcomplete.zsh
+@@ -20,6 +20,6 @@ autoload -U +X bashcompinit && bashcompinit
+ # Get this scripts directory
+ __ros2cli_completion_dir=${0:a:h}
+ # Just source the bash version, it works in zsh too
+-source "$__ros2cli_completion_dir/ros2-argcomplete.bash"
++source "$CONDA_PREFIX/share/bash-completion/completions/ros2-argcomplete.bash"
+ # Cleanup
+ unset __ros2cli_completion_dir
+diff --git a/ros2cli/setup.py b/ros2cli/setup.py
+index 4f75422..1ba8012 100644
+--- a/ros2cli/setup.py
++++ b/ros2cli/setup.py
+@@ -23,6 +23,14 @@ setup(
+             'completion/ros2-argcomplete.bash',
+             'completion/ros2-argcomplete.zsh'
+         ]),
++
++        # [pixi] install autocompletion scripts
++        ('share/bash-completion/completions', [
++            'completion/ros2-argcomplete.bash',
++        ]),
++        ('share/zsh/site-functions', [
++            'completion/ros2-argcomplete.zsh'
++        ]),
+     ],
+     zip_safe=False,
+     author='Dirk Thomas',

--- a/patch/ros-kilted-rosidl.patch
+++ b/patch/ros-kilted-rosidl.patch
@@ -1,0 +1,31 @@
+diff --git a/rosidl_cli/completion/rosidl-argcomplete.zsh b/rosidl_cli/completion/rosidl-argcomplete.zsh
+index 9a86dbd..a33f8e1 100644
+--- a/rosidl_cli/completion/rosidl-argcomplete.zsh
++++ b/rosidl_cli/completion/rosidl-argcomplete.zsh
+@@ -18,6 +18,6 @@ autoload -U +X bashcompinit && bashcompinit
+ # Get this scripts directory
+ __rosidl_cli_completion_dir=${0:a:h}
+ # Just source the bash version, it works in zsh too
+-source "$__rosidl_cli_completion_dir/rosidl-argcomplete.bash"
++source "$CONDA_PREFIX/share/bash-completion/completions/rosidl-argcomplete.bash"
+ # Cleanup
+ unset __rosidl_cli_completion_dir
+diff --git a/rosidl_cli/setup.py b/rosidl_cli/setup.py
+index 6cfca9a..bebd655 100644
+--- a/rosidl_cli/setup.py
++++ b/rosidl_cli/setup.py
+@@ -23,6 +23,14 @@ setup(
+             'completion/rosidl-argcomplete.bash',
+             'completion/rosidl-argcomplete.zsh'
+         ]),
++
++        # [pixi] install autocompletion scripts
++        ('share/bash-completion/completions', [
++            'completion/rosidl-argcomplete.bash',
++        ]),
++        ('share/zsh/site-functions', [
++            'completion/rosidl-argcomplete.zsh'
++        ]),
+     ],
+     zip_safe=False,
+     author='Michel Hidalgo',

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -176,3 +176,7 @@ camera_calibration:
   build_number: 22
 nav2_smac_planner:
   build_number: 22
+rosidl_cli:
+  build_number: 22
+ros2cli:
+  build_number: 22

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -176,7 +176,7 @@ camera_calibration:
   build_number: 22
 nav2_smac_planner:
   build_number: 22
-rosidl_cli:
-  build_number: 22
 ros2cli:
+  build_number: 22
+rosidl_cli:
   build_number: 22

--- a/tests/ros-kilted-ros2cli.yaml
+++ b/tests/ros-kilted-ros2cli.yaml
@@ -1,0 +1,7 @@
+tests:
+  # Regression test for https://github.com/RoboStack/ros-humble/issues/271
+  - script:
+    - if: unix
+      then:
+        - test -f ${PREFIX}/share/bash-completion/completions/ros2-argcomplete.bash
+        - test -f ${PREFIX}/share/zsh/site-functions/ros2-argcomplete.zsh

--- a/tests/ros-kilted-rosidl.yaml
+++ b/tests/ros-kilted-rosidl.yaml
@@ -1,0 +1,7 @@
+tests:
+  # Regression test for https://github.com/RoboStack/ros-humble/issues/271
+  - script:
+    - if: unix
+      then:
+        - test -f ${PREFIX}/share/bash-completion/completions/rosidl-argcomplete.bash
+        - test -f ${PREFIX}/share/zsh/site-functions/rosidl-argcomplete.zsh


### PR DESCRIPTION
Allows a user to run `ros2 <TABTAB>` and get the proper results. This does add a few miliseconds (100ms) of activation to the `pixi shell`.

- Patches the zsh script to link to the location of the bash script through the CONDA_PREFIX instead of assuming local install.