### PR TITLE
Bump build number of rosidl_generator_rs to ensure rebuild

### DIFF
--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -176,3 +176,5 @@ camera_calibration:
   build_number: 22
 nav2_smac_planner:
   build_number: 22
+rosidl_generator_rs:
+  build_number: 22


### PR DESCRIPTION
I would have expected that bumping the version number in https://github.com/RoboStack/ros-kilted/pull/98 was sufficient to rebuild the package, but apparently that is not the case. In this PR we also bump the rosidl_generator_rs build number to ensure it gets build.